### PR TITLE
rfctr(part): add new decorator to replace four (#3650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.15.14-dev3
+## 0.15.14-dev4
 
 ### Enhancements
 
 ### Features
+
+* **Add (but do not install) a new post-partitioning decorator to handle metadata added for all file-types, like `.filename`, `.filetype` and `.languages`.** This will be installed in a closely following PR to replace the four currently being used for this purpose.
 
 ### Fixes
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.14-dev3"  # pragma: no cover
+__version__ = "0.15.14-dev4"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -14,7 +14,7 @@ from unstructured.file_utils.filetype import detect_filetype, is_json_processabl
 from unstructured.file_utils.model import FileType
 from unstructured.logger import logger
 from unstructured.partition.common.common import exactly_one
-from unstructured.partition.lang import check_language_args
+from unstructured.partition.common.lang import check_language_args
 from unstructured.partition.utils.constants import PartitionStrategy
 from unstructured.utils import dependency_exists
 

--- a/unstructured/partition/common/metadata.py
+++ b/unstructured/partition/common/metadata.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import datetime as dt
+import functools
 import os
-from typing import Optional, Sequence
+from typing import Any, Callable, Sequence
 
-from unstructured.documents.elements import Element
+from typing_extensions import ParamSpec
+
+from unstructured.documents.elements import Element, ElementMetadata, assign_and_map_hash_ids
+from unstructured.file_utils.model import FileType
+from unstructured.partition.common.lang import apply_lang_metadata
+from unstructured.utils import get_call_args_applying_defaults
+
+_P = ParamSpec("_P")
 
 
-def get_last_modified_date(filename: str) -> Optional[str]:
+def get_last_modified_date(filename: str) -> str | None:
     """Modification time of file at path `filename`, if it exists.
 
     Returns `None` when `filename` is not a path to a file on the local filesystem.
@@ -54,9 +62,9 @@ HIERARCHY_RULE_SET = {
 def set_element_hierarchy(
     elements: Sequence[Element], ruleset: dict[str, list[str]] = HIERARCHY_RULE_SET
 ) -> list[Element]:
-    """Sets the parent_id for each element in the list of elements
-    based on the element's category, depth and a ruleset
+    """Sets `.metadata.parent_id` for each element it applies to.
 
+    `parent_id` assignment is based on the element's category, depth and a ruleset.
     """
     stack: list[Element] = []
     for element in elements:
@@ -97,3 +105,104 @@ def set_element_hierarchy(
         stack.append(element)
 
     return list(elements)
+
+
+# ================================================================================================
+# METADATA POST-PARTITIONING PROCESSING DECORATOR
+# ================================================================================================
+
+
+def apply_metadata(
+    file_type: FileType | None = None,
+) -> Callable[[Callable[_P, list[Element]]], Callable[_P, list[Element]]]:
+    """Post-process element-metadata for this document.
+
+    This decorator adds a post-processing step to a partitioner, primarily to apply metadata that
+    is common to all partitioners. It assumes the following responsibilities:
+
+      - Hash element-ids. Computes and applies SHA1 hash element.id when `unique_element_ids`
+        argument is False.
+
+      - Element Hierarchy. Computes and applies `parent_id` metadata based on `category_depth`
+        etc. added by partitioner.
+
+      - Language metadata. Computes and applies `language` metadata based on a language detection
+        model.
+
+      - Apply `filetype` (MIME-type) metadata. There are three cases; first one in this order that
+        applies is used:
+
+          - `metadata_file_type` argument is present in call, use that.
+          - `file_type` decorator argument is populated, use that.
+          - `file_type` decorator argument is omitted or None, don't apply `.metadata.filetype`
+            (assume the partitioner will do that for itself, like `partition_image()`.
+
+      - Replace `filename` with `metadata_filename` when present.
+
+      - Apply `url` metadata when present.
+    """
+
+    def decorator(func: Callable[_P, list[Element]]) -> Callable[_P, list[Element]]:
+        """The decorator function itself.
+
+        This function is returned by the `apply_metadata()` function and is the actual decorator.
+        Think of `apply_metadata()` as a factory function that configures this decorator, in
+        particular by setting its `file_type` value.
+        """
+
+        @functools.wraps(func)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> list[Element]:
+            elements = func(*args, **kwargs)
+            call_args = get_call_args_applying_defaults(func, *args, **kwargs)
+
+            # -- Compute and apply hash-ids if the user does not want UUIDs. Note this changes the
+            # -- elements themselves, not the metadata.
+            unique_element_ids: bool = call_args.get("unique_element_ids", False)
+            if unique_element_ids is False:
+                elements = assign_and_map_hash_ids(elements)
+
+            # -- `parent_id` - process category-level etc. to assign parent-id --
+            elements = set_element_hierarchy(elements)
+
+            # -- `language` - auto-detect language (e.g. eng, spa) --
+            languages = call_args.get("languages")
+            detect_language_per_element = call_args.get("detect_language_per_element", False)
+            elements = list(
+                apply_lang_metadata(
+                    elements=elements,
+                    languages=languages,
+                    detect_language_per_element=detect_language_per_element,
+                )
+            )
+
+            # == apply filetype, filename, and url metadata =========================
+            metadata_kwargs: dict[str, Any] = {}
+
+            # -- `filetype` (MIME-type) metadata --
+            metadata_file_type = call_args.get("metadata_file_type") or file_type
+            if metadata_file_type is not None:
+                metadata_kwargs["filetype"] = metadata_file_type.mime_type
+
+            # -- `filename` metadata - override with metadata_filename when it's present --
+            filename = call_args.get("metadata_filename") or call_args.get("filename")
+            if filename:
+                metadata_kwargs["filename"] = filename
+
+            # -- `url` metadata - record url when present --
+            url = call_args.get("url")
+            if url:
+                metadata_kwargs["url"] = url
+
+            # -- update element.metadata in single pass --
+            for element in elements:
+                # NOTE(robinson) - Attached files have already run through this logic in their own
+                # partitioning function
+                if element.metadata.attached_to_filename:
+                    continue
+                element.metadata.update(ElementMetadata(**metadata_kwargs))
+
+            return elements
+
+        return wrapper
+
+    return decorator

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -16,8 +16,8 @@ from unstructured.documents.elements import (
 )
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.utils import is_temp_file_path, lazyproperty
 
 DETECTION_ORIGIN: str = "csv"

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -46,8 +46,8 @@ from unstructured.documents.elements import (
 )
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_email_address,

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -47,9 +47,9 @@ from unstructured.file_utils.model import FileType
 from unstructured.logger import logger
 from unstructured.nlp.patterns import EMAIL_DATETIMETZ_PATTERN_RE
 from unstructured.partition.common.common import convert_to_bytes, exactly_one
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.html import partition_html
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text import partition_text
 
 VALID_CONTENT_SOURCES: Final[list[str]] = ["text/html", "text/plain"]
@@ -101,7 +101,7 @@ def partition_email_header(msg: EmailMessage) -> list[Element]:
         for addr in header.addresses:
             elements.append(
                 element_type(
-                    name=addr.display_name or addr.username,
+                    name=addr.display_name or addr.username,  # type: ignore
                     text=addr.addr_spec,  # type: ignore
                 )
             )

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -14,9 +14,9 @@ from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.encoding import read_txt_file
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.html.parser import Flow, html_parser
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.utils import is_temp_file_path, lazyproperty
 
 

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -6,7 +6,7 @@ from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import add_metadata
 from unstructured.partition.common.common import exactly_one
-from unstructured.partition.lang import check_language_args
+from unstructured.partition.common.lang import check_language_args
 from unstructured.partition.pdf import partition_pdf_or_image
 from unstructured.partition.utils.constants import PartitionStrategy
 

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -14,9 +14,9 @@ from unstructured.documents.elements import Element, ElementMetadata, process_me
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
 from unstructured.logger import logger
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.html import partition_html
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text import partition_text
 from unstructured.utils import is_temp_file_path, lazyproperty
 

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -48,12 +48,12 @@ from unstructured.partition.common.common import (
     ocr_data_to_elements,
     spooled_to_bytes_io_if_needed,
 )
-from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import (
+from unstructured.partition.common.lang import (
     check_language_args,
     prepare_languages_for_tesseract,
     tesseract_to_paddle_language,
 )
+from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.pdf_image.analysis.layout_dump import (
     ExtractedLayoutDumper,
     FinalLayoutDumper,

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -37,8 +37,8 @@ from unstructured.documents.elements import (
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import convert_ms_office_table_to_text
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text_type import (
     is_email_address,
     is_possible_narrative_text,

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -30,8 +30,8 @@ from unstructured.file_utils.model import FileType
 from unstructured.nlp.patterns import PARAGRAPH_PATTERN, UNICODE_BULLETS_RE
 from unstructured.nlp.tokenize import sent_tokenize
 from unstructured.partition.common.common import exactly_one
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_email_address,

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -18,8 +18,8 @@ from unstructured.partition.common.common import (
     exactly_one,
     spooled_to_bytes_io_if_needed,
 )
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 
 DETECTION_ORIGIN: str = "tsv"
 

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -26,8 +26,8 @@ from unstructured.documents.elements import (
 )
 from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_possible_narrative_text,

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -20,8 +20,8 @@ from unstructured.partition.common.common import (
     exactly_one,
     spooled_to_bytes_io_if_needed,
 )
+from unstructured.partition.common.lang import apply_lang_metadata
 from unstructured.partition.common.metadata import get_last_modified_date
-from unstructured.partition.lang import apply_lang_metadata
 from unstructured.partition.text import element_from_text
 
 DETECTION_ORIGIN: str = "xml"


### PR DESCRIPTION
**Summary**
In preparation for pluggable auto-partitioners, add a new metadata decorator to replace the four existing ones.

**Additional Context**
"Global" metadata items, those applied to all element on all partitioners, are applied using a decorator.

Currently there are four decorators where there only needs to be one. Consolidate those into a single metadata decorator. One or two additional behaviors of the new decorator will allow us to remove decorators from delegating partitioners which is a prerequisite for pluggable auto-partitioners.